### PR TITLE
rpm: require kexec for building and running

### DIFF
--- a/nmbl-builder.spec.in
+++ b/nmbl-builder.spec.in
@@ -25,6 +25,7 @@ BuildRequires: grub2-tools-minimal
 BuildRequires: kernel-core
 BuildRequires: kernel-modules
 BuildRequires: kernel-modules-core
+BuildRequires: kexec-tools
 BuildRequires: keyutils
 BuildRequires: lvm2
 BuildRequires: make
@@ -44,6 +45,7 @@ the linux kernel and grub-emu, using either switchroot or kexec.
 Summary: nmbl proof of concept as a package
 Version: %{kver}
 Release: %{krel}
+Requires: kexec-tools
 
 %description -n nmbl
 nmbl-poc is a proof of concept for a bootloader for UEFI machines based on


### PR DESCRIPTION
Otherwise kexec may mysteriously fail since grub doesn't distinguish "executable not found" and "everything failed".