### PR TITLE
Put the kexec-tools "Requires:" in dracut-nmbl instead.

### DIFF
--- a/dracut-nmbl.spec.in
+++ b/dracut-nmbl.spec.in
@@ -14,6 +14,8 @@ URL: https://github.com/rhboot/nmbl-poc
 BuildRequires: git
 BuildRequires: make
 
+Requires: kexec-tools
+
 Source0: dracut-nmbl-%{version}.tar.xz
 
 %description

--- a/nmbl-builder.spec.in
+++ b/nmbl-builder.spec.in
@@ -45,7 +45,6 @@ the linux kernel and grub-emu, using either switchroot or kexec.
 Summary: nmbl proof of concept as a package
 Version: %{kver}
 Release: %{krel}
-Requires: kexec-tools
 
 %description -n nmbl
 nmbl-poc is a proof of concept for a bootloader for UEFI machines based on


### PR DESCRIPTION
The reason we can't kexec is /usr/sbin/kexec isn't there.  Robbie correctly noted that we would have expected dracut to error on this case, and it's strange that it doesn't.

So this change works around the dracut error in a way, but it also ensures we have the kexec binary we think we do by making it be required in the RPMs.

I suspect in some sense the BuildRequires in the nmbl package basically all need to be Requires in the dracut-nmbl result package, but I didn't go that far here because it's governed by the config files, which come from the nmbl package currently.