### PR TITLE
script: rootfs: Script to set the correct cmdline parameters for rootfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ cp nmbl.uki.signed /boot/efi/EFI/fedora/nmbl.uki
 ## make a new efibootmgr entry
 ```bash
 efibootmgr -q -b 0010 -B ;
-echo -n "\nmbl.uki quiet boot=$(awk '/ \/boot / {print $1}' /etc/fstab) rd.systemd.gpt_auto=0" \
+echo -n "\nmbl.uki quiet $(./scripts/guess_rootfs.sh) boot=$(awk '/ \/boot / {print $1}' /etc/fstab) rd.systemd.gpt_auto=0" \
 | iconv -f UTF8 -t UCS-2LE \
 | efibootmgr -b 0010 -C -d /dev/vda -p 1 -L nmbl -l /EFI/fedora/shimx64.efi -@ - -n 0010
 ```

--- a/scripts/guess_rootfs.sh
+++ b/scripts/guess_rootfs.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+check_lvm () {
+    lsblk -f | grep "LVM" > /dev/null 2>&1
+}
+
+set_lvm () {
+    root=$(mount | grep " / " | awk '{print $1}')
+    rd_lvm_lv=$(grep -oP '(?<=rd.lvm.lv=)[^ ]*' /proc/cmdline)
+    echo "root=$root ro rd.lvm.lv=$rd_lvm_lv"
+    exit
+}
+
+check_btrfs () {
+    fs=$(lsblk -f | grep "$(awk '/ \/ / {print $1}' /etc/fstab | grep -oP '(?<=UUID=)[^ ]*')" | awk '{print $2}')
+    if [ "$fs" = "btrfs" ]
+    then
+	    set_btrfs
+    fi
+}
+
+set_btrfs () {
+    root=$(grep -oP '(?<=root=)[^ ]*' /proc/cmdline)
+    rootflags=$(grep -oP '(?<=rootflags=)[^ ]*' /proc/cmdline)
+    echo "root=$root ro rootflags=$rootflags"
+    exit
+}
+
+set_standard () {
+    root=$(grep -oP '(?<=root=)[^ ]*' /proc/cmdline)
+    echo "root=$root ro"
+    exit
+}
+
+if check_lvm
+then
+    set_lvm
+fi
+
+check_btrfs
+
+set_standard


### PR DESCRIPTION
The scripts/guess_rootfs.sh script will parse available files on the host machine to set the root filesystem mount parameters for BTRFS, LVM and standard partitions.